### PR TITLE
Manifest V3対応

### DIFF
--- a/extension/action/popup.js
+++ b/extension/action/popup.js
@@ -22,8 +22,16 @@ const initActions = (tab) => {
   const clearCommentsButton = document.getElementById("clear-comments");
 
   showCommentsButton.addEventListener("click", () => {
-    chrome.tabs.executeScript(tab.id, { file: "content/presentation.js" });
-    chrome.tabs.insertCSS(tab.id, { file: "content/presentation.css" });
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ["content/presentation.js"]
+    });
+    chrome.scripting.insertCSS({
+      target: {
+        tabId: tab.id,
+      },
+      files: ["content/presentation.css"]
+    });
     showCommentsButton.setAttribute("disabled", "true");
     chrome.runtime.sendMessage({ addTabId: tab.id });
   });

--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -74,7 +74,7 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
 });
 
 const sendMessage = (message) => {
-  chrome.runtime.sendMessage(message);
+  // chrome.runtime.sendMessage(message);
   chrome.tabs.query({ active: true }, (tabs) => {
     tabs.forEach((tab) => chrome.tabs.sendMessage(tab.id, message));
   });

--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -11,22 +11,28 @@ const defaultPreference = {
 
 const isEmptyObject = (obj) => Object.keys(obj).length === 0;
 
-chrome.runtime.onInstalled.addListener(async () => {
-  // initialize or migrate
-  const local = await chrome.storage.local.get(LOCAL_STORAGE_PREFERENCE_KEY);
+chrome.runtime.onInstalled.addListener(() => {
+  (async () => {
+    // initialize or migrate
+    const local = await chrome.storage.local.get(LOCAL_STORAGE_PREFERENCE_KEY);
 
-  const initialPreference = JSON.parse(
-    isEmptyObject(local)
-      ? '{"version": 0}'
-      : local[LOCAL_STORAGE_PREFERENCE_KEY]
-  );
+    const initialPreference = JSON.parse(
+      isEmptyObject(local)
+        ? '{"version": 0}'
+        : local[LOCAL_STORAGE_PREFERENCE_KEY]
+    );
 
-  if (initialPreference.version < 2) {
-    const migrated = { ...defaultPreference, ...initialPreference, version: 2 };
-    await chrome.storage.local.set({
-      [LOCAL_STORAGE_PREFERENCE_KEY]: JSON.stringify(migrated),
-    });
-  }
+    if (initialPreference.version < 2) {
+      const migrated = {
+        ...defaultPreference,
+        ...initialPreference,
+        version: 2,
+      };
+      await chrome.storage.local.set({
+        [LOCAL_STORAGE_PREFERENCE_KEY]: JSON.stringify(migrated),
+      });
+    }
+  })();
 });
 
 const tabIds = new Set();
@@ -36,41 +42,49 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   }
 });
 
-chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
-  console.log(request);
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  (async () => {
+    console.log(request);
 
-  if ("hasTabId" in request) {
-    sendResponse({ result: tabIds.has(request.hasTabId) });
-    return;
-  }
-  if ("addTabId" in request) {
-    tabIds.add(request.addTabId);
-    return;
-  }
-  if ("getPreference" in request) {
-    const local = await chrome.storage.local.get(LOCAL_STORAGE_PREFERENCE_KEY);
-    const json = isEmptyObject(local)
-      ? "{}"
-      : local[LOCAL_STORAGE_PREFERENCE_KEY];
+    if ("hasTabId" in request) {
+      sendResponse({ result: tabIds.has(request.hasTabId) });
+      return;
+    }
+    if ("addTabId" in request) {
+      tabIds.add(request.addTabId);
+      return;
+    }
+    if ("getPreference" in request) {
+      const local = await chrome.storage.local.get(
+        LOCAL_STORAGE_PREFERENCE_KEY
+      );
+      const json = isEmptyObject(local)
+        ? "{}"
+        : local[LOCAL_STORAGE_PREFERENCE_KEY];
 
-    sendResponse({
-      [LOCAL_STORAGE_PREFERENCE_KEY]: JSON.parse(json),
-    });
-    return;
-  }
-  if ("setPreference" in request) {
-    const local = await chrome.storage.local.get(LOCAL_STORAGE_PREFERENCE_KEY);
-    const json = isEmptyObject(local)
-      ? "{}"
-      : local[LOCAL_STORAGE_PREFERENCE_KEY];
-    const preference = { ...JSON.parse(json), ...request.setPreference };
-    await chrome.storage.local.set({
-      [LOCAL_STORAGE_PREFERENCE_KEY]: JSON.stringify(preference),
-    });
-    sendMessage({ preference });
-    return;
-  }
-  sendMessage(request);
+      sendResponse({
+        [LOCAL_STORAGE_PREFERENCE_KEY]: JSON.parse(json),
+      });
+      return;
+    }
+    if ("setPreference" in request) {
+      const local = await chrome.storage.local.get(
+        LOCAL_STORAGE_PREFERENCE_KEY
+      );
+      const json = isEmptyObject(local)
+        ? "{}"
+        : local[LOCAL_STORAGE_PREFERENCE_KEY];
+      const preference = { ...JSON.parse(json), ...request.setPreference };
+      await chrome.storage.local.set({
+        [LOCAL_STORAGE_PREFERENCE_KEY]: JSON.stringify(preference),
+      });
+      sendMessage({ preference });
+      return;
+    }
+    sendMessage(request);
+  })();
+
+  return true;
 });
 
 const sendMessage = (message) => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,7 @@
     "128": "icon.png"
   },
   "manifest_version": 3,
-  "permissions": ["storage", "activeTab"],
+  "permissions": ["storage", "scripting", "activeTab"],
   "background": {
     "service_worker": "background/background.js"
   },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Slarrage",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "icons": {
     "128": "icon.png"
   },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "icons": {
     "128": "icon.png"
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "permissions": ["activeTab"],
   "background": {
     "scripts": ["background/background.js"]

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,7 @@
   "manifest_version": 3,
   "permissions": ["activeTab"],
   "background": {
-    "scripts": ["background/background.js"]
+    "service_worker": "background/background.js"
   },
   "content_scripts": [
     {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,7 @@
       "js": ["content/observer.js", "content/watchingAlert.js"]
     }
   ],
-  "browser_action": {
+  "action": {
     "default_title": "Slarrage",
     "default_popup": "action/popup.html"
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,7 @@
     "128": "icon.png"
   },
   "manifest_version": 3,
-  "permissions": ["activeTab"],
+  "permissions": ["storage", "activeTab"],
   "background": {
     "service_worker": "background/background.js"
   },


### PR DESCRIPTION
## やったこと

- Manifest V3対応しました
	- localStorageは `chrome.storage` APIへ移行
	- backgroundスクリプトはService Workerへ移行
	- `chrome.tabs.executeScript`, `chrome.tabs.insertCSS` を `chrome.scripting` APIへ移行

動いているけど、コードはもうちょっとなんとかなるのでは？という気がしている